### PR TITLE
Class Portrait update

### DIFF
--- a/modules/portrait.lua
+++ b/modules/portrait.lua
@@ -71,8 +71,12 @@ function Portrait:Update(frame, event)
 	if( type == "class" ) then
 		local classToken = select(2, UnitClass(frame.unitOwner))
 		if( classToken ) then
-			frame.portrait:SetTexture("Interface\\Glues\\CharacterCreate\\UI-CharacterCreate-Classes")
-			frame.portrait:SetTexCoord(CLASS_ICON_TCOORDS[classToken][1], CLASS_ICON_TCOORDS[classToken][2], CLASS_ICON_TCOORDS[classToken][3], CLASS_ICON_TCOORDS[classToken][4])
+			local classIconAtlas = GetClassAtlas(classToken)
+			if( classIconAtlas ) then
+				frame.portrait:SetAtlas(classIconAtlas)
+			else
+				frame.portrait:SetTexture("")
+			end
 		else
 			frame.portrait:SetTexture("")
 		end


### PR DESCRIPTION
Hi.
Class icon portraits are looking very dated. Changed them to better, high res versions.
( Filename which contains these: "interface/glues/charactercreate/charactercreateicons.blp" )
Preview:
left is current, right is new

![class_portrait](https://github.com/Shadowed/ShadowedUnitFrames/assets/272450/4e194fbe-356f-4b5f-8889-7f0c312dcf05)
